### PR TITLE
puppeteer 20 & headless: 'new'

### DIFF
--- a/getmastodon.js
+++ b/getmastodon.js
@@ -43,7 +43,7 @@ if (!theurl) {
     console.log('url= is required');
 } else {
     (async () => {
-        const browser = await puppeteer.launch()
+        const browser = await puppeteer.launch({headless: 'new'})
         const page = await browser.newPage()
 
         await page.setViewport({

--- a/gettweet.js
+++ b/gettweet.js
@@ -46,7 +46,7 @@ if (!theurl) {
     console.log('url= is required');
 } else {
     (async() => {
-        const browser = await puppeteer.launch()
+        const browser = await puppeteer.launch({headless: 'new'})
         const page = await browser.newPage()
 
         await page.setViewport({

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "imagemin-pngquant": "^9.0.2",
         "imagemin-webp": "^8.0.0",
         "node-fetch": "^3.3.1",
-        "puppeteer": "^19.9.0",
+        "puppeteer": "^20.2.0",
         "string-strip-html": "^13.2.2"
     }
 }


### PR DESCRIPTION
### Moves to puppeteer 20

now uses [`headless: 'new'](https://developer.chrome.com/articles/new-headless/#new-headless-in-puppeteer)